### PR TITLE
add: auth 서비스 배포 위한 yaml 추가

### DIFF
--- a/code/kubernetes/msa-auth/deployment-prod.yaml
+++ b/code/kubernetes/msa-auth/deployment-prod.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cowing-msa-auth-deployment
+  labels:
+    app: cowing-msa-auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cowing-msa-auth
+  template:
+    metadata:
+      labels:
+        app: cowing-msa-auth
+        cowing: auth
+    spec:
+      containers:
+        - name: cowing-msa-auth
+          image: ghcr.io/coinwing/cowing-msa-auth:main
+          imagePullPolicy: Always
+          env:
+            - name: REDIS_HOST
+              value: "redis-service"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: DB_URL
+              value: "jdbc:mariadb://mariadb-service:3306/cowingDB"
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mardiadb-secret
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mardiadb-secret
+                  key: password
+            - name: JWT_SECRET
+              value: "99f461065038a0d63d66ad26d52bf68a76ad3b0d7cb576f2b67cd8d9e75230e9"
+            - name: ACCESS_TOKEN_EXPIRE
+              value: "86400000"
+            - name: REFRESH_TOKEN_EXPIRE
+              value: "172800000"
+          resources:
+            limits:
+              memory: "700Mi"
+              cpu: 500m
+            requests:
+              memory: "512Mi"
+              cpu: 200m
+          ports:
+            - containerPort: 8082
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 180
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 180
+            periodSeconds: 15
+            failureThreshold: 5
+      imagePullSecrets:
+        - name: ghcr-login-secret

--- a/code/kubernetes/msa-auth/redis-pod-prod.yaml
+++ b/code/kubernetes/msa-auth/redis-pod-prod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis-pod
+  labels:
+    app: redis
+spec:
+  containers:
+    - name: redis
+      image: redis:alpine
+      command: ["sh", "-c"]
+      args:
+        - redis-server --appendonly no --save ''
+      resources:
+        limits:
+          memory: 200Mi
+          cpu: 200m
+        requests:
+          memory: 100Mi
+          cpu: 100m
+      ports:
+        - containerPort: 6379

--- a/code/kubernetes/msa-auth/redis-svc-prod.yaml
+++ b/code/kubernetes/msa-auth/redis-svc-prod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-service
+spec:
+  selector:
+    app: redis
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379

--- a/code/kubernetes/msa-auth/service-prod.yaml
+++ b/code/kubernetes/msa-auth/service-prod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cowing-msa-auth-service
+spec:
+  selector:
+    app: cowing-msa-auth
+  ports:
+    - protocol: TCP
+      port: 8082
+      targetPort: 8082
+  type: ClusterIP


### PR DESCRIPTION
마리아DB는 공용으로 사용하기 때문에 auth 디플로이먼트와 서비스 / Redis 파드와 서비스 yaml만 작성했습니다.