### PR TITLE
Terraform 테스트 환경 수정

### DIFF
--- a/code/terraform/dev/.terraform.lock.hcl
+++ b/code/terraform/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.9.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:tYd0S1e8xSwAM3NtDrvu2e80pV9fvLEWAjhtDR4JP5o=",
+    "zh:0121aeca90856ba37d03cff9eed40321cc3ae1c0f77bef3329e17212c48f884a",
+    "zh:4f09e73f948d4545358eed978bc41fd1a825c65b530a532bfaf9aaba93ac6e55",
+    "zh:58604213402b5dba8360367e09b3d3762736980c80a72d6297be7cb71fe8dc8d",
+    "zh:5aa9fe54fc9aba0780cae11becfce698e5093ee002066590599277d5aa71e59e",
+    "zh:7e8546575a80d54b8db7edb53574c2d1f04afbdbafc599d0eb78da9e74e917f7",
+    "zh:846ce59c9f7ec3c92b33fe3a0d98386420bcbb971260da9ff869b219a1125df4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bd2cb527dcbd76977c18f3f6844638b6d5039f070accc41d064831f98aa7b40",
+    "zh:9df98266de85cf047c9a2e43b892c74479805e0936dbb3583aef314d2fa0f5fc",
+    "zh:a4fc8e9645b147902bcf36f10ea1891ca92661c4ee4135046cc79b8ce6fe1093",
+    "zh:afe3029760f7aa5484e26c80670f86b6b5054126776376ba6aec4aa8a41483ce",
+    "zh:c158cd1790422237ab2a2e10fc02e5522bd7bce39c067ffbc9edda1e6c9ebf3b",
+    "zh:f5408929d5df6f81fcb93a433e0dbc0432b748b400cc41910328b936a7590fd5",
+    "zh:f6331bb27134e288d8c324b2390c610fd924f71af1ec27f79070dfa26f4dd410",
+    "zh:f6b8b429d5fa71f186bda45468bbde230a1697a38480487f41d7172f1e374e2d",
+  ]
+}

--- a/code/terraform/dev/docker-compose.yml
+++ b/code/terraform/dev/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  localstack:
+    container_name: localstack
+    image: localstack/localstack:latest
+    read_only: false  
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+    environment:
+      - DEBUG=1terraform init -upgrade
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock" 
+    security_opt:
+      - no-new-privileges:true

--- a/code/terraform/dev/main.tf
+++ b/code/terraform/dev/main.tf
@@ -1,0 +1,94 @@
+locals {
+  project_name = "cowing"
+  env          = "dev"
+}
+
+
+module "s3" {
+  source       = "../modules/s3"
+  project_name = local.project_name
+  env          = local.env
+}
+
+module "dynamodb" {
+  source       = "../modules/dynamodb"
+  project_name = local.project_name
+  env          = local.env
+}
+
+module "sqs" {
+  source       = "../modules/sqs"
+  project_name = local.project_name
+  env          = local.env
+  queue_name   = "${local.project_name}-${local.env}-sqs"
+
+  fifo                         = true
+  content_based_deduplication = false
+  visibility_timeout_seconds   = 30
+  message_retention_seconds    = 18000
+  delay_seconds                = 0
+  max_message_size             = 1024
+  receive_wait_time_seconds    = 5
+}
+
+module "iam" {
+  source       = "../modules/iam"
+  project_name = local.project_name
+  env          = local.env
+}
+
+# Minimal network just for EC2 module testing (kept local to dev)
+resource "aws_vpc" "dev" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${local.project_name}-${local.env}-vpc" }
+}
+
+resource "aws_subnet" "dev_public" {
+  vpc_id                  = aws_vpc.dev.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-2a"
+  map_public_ip_on_launch = true
+
+  tags = { Name = "${local.project_name}-${local.env}-public-1" }
+}
+
+resource "aws_security_group" "nat_sg" {
+  name        = "${local.project_name}-${local.env}-nat-sg-dev"
+  description = "NAT instance SG (dev)"
+  vpc_id      = aws_vpc.dev.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${local.project_name}-${local.env}-nat-sg-dev" }
+}
+
+resource "aws_security_group" "bastion_sg" {
+  name        = "${local.project_name}-${local.env}-bastion-sg-dev"
+  description = "Bastion host SG (dev)"
+  vpc_id      = aws_vpc.dev.id
+
+  # Optional: allow SSH for realism (not required by LocalStack)
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${local.project_name}-${local.env}-bastion-sg-dev" }
+}

--- a/code/terraform/dev/outputs.tf
+++ b/code/terraform/dev/outputs.tf
@@ -1,0 +1,3 @@
+output "sqs_queue_url" {
+  value = module.sqs.queue_url
+}

--- a/code/terraform/dev/provider.tf
+++ b/code/terraform/dev/provider.tf
@@ -1,0 +1,30 @@
+# LocalStack AWS provider configuration for local testing
+provider "aws" {
+  access_key = "test"
+  secret_key = "test"
+  region     = "ap-northeast-2"
+
+  s3_use_path_style           = true
+  skip_requesting_account_id  = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+
+  endpoints {
+    cloudwatch     = "http://localhost:4566"
+    cloudwatchlogs = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    ec2            = "http://localhost:4566"
+    elasticache    = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    rds            = "http://localhost:4566"
+    route53        = "http://localhost:4566"
+    s3             = "http://localhost:4566"
+    secretsmanager = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
+}

--- a/code/terraform/dev/tests/localstack.tftest.hcl
+++ b/code/terraform/dev/tests/localstack.tftest.hcl
@@ -1,0 +1,63 @@
+provider "aws" {
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "ap-northeast-2"
+  s3_use_path_style           = true
+  skip_requesting_account_id  = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+
+  endpoints {
+    cloudwatch     = "http://localhost:4566"
+    cloudwatchlogs = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    ec2            = "http://localhost:4566"
+    elasticache    = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    rds            = "http://localhost:4566"
+    route53        = "http://localhost:4566"
+    s3             = "http://localhost:4566"
+    secretsmanager = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
+}
+
+run "Test_Check" {
+
+  command = apply
+
+  assert {
+    condition     = output.sqs_queue_url != null
+    error_message = "SQS queue not created"
+  }
+
+}
+
+# run "check_dynamodb_table" {
+#   command = apply
+#   variables{
+#     enable_ec2 = false
+#   }
+
+#   assert {
+#     condition     = output.dynamodb_table_name == var.dynamodb_table_name
+#     error_message = "DynamoDB table not created or name mismatch"
+#   }
+# }
+
+# run "check_ec2_stack" {
+#   command = apply
+#   variables{
+#     enable_ec2 = true
+#   }
+
+#   assert {
+#     condition     = output.bastion_host_id_test != null && output.nat_instance_eni_id_test != null
+#     error_message = "EC2 stack (bastion/nat) not created"
+#   }
+# }

--- a/code/terraform/dev/versions.tf
+++ b/code/terraform/dev/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
# ✏️ 요약
Terraform 테스트 환경을 수정하였다. 

# 🔢  설명
기본적으로 프리티어가 있거나 단일 모듈만 테스트한다면 비용이 발생하지 않는다. 
또한, 기존 환경(디렉토리)는 불필요하게 많은 파일이 들어가 있었기 때문에 이후에 테스트 과정에서 활용할 수 있도록 필요한 모듈만 생성해두고 했다. 전체적으로 파일 갯수를 줄이고 필요한 파일만 `terraform/dev`로 옮겼다.